### PR TITLE
Upgrade to tendermint@4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -380,11 +380,26 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "follow-redirects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "for-each": {
@@ -1161,9 +1176,9 @@
       "integrity": "sha1-H8/p/F/25CrvTjaDY2yMuJFZSxg="
     },
     "tendermint": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/tendermint/-/tendermint-3.4.2.tgz",
-      "integrity": "sha512-7/h8QY2gxxLdOUWvM1dUt8LlDqVnUQPX3HIabWaTZ6PKl91+BDlJLf30FvCae9SnS7DEf1MSZlkkudSVO+Z3ng==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/tendermint/-/tendermint-4.0.2.tgz",
+      "integrity": "sha512-bGvLuvk8JBGXgw5m4GQfRmXNENiqwQyymqYAh/DwtN0X7f9SNZouhRt4Vh3WHkfOoO3sFGCie0PqbhumKkucGg==",
       "requires": {
         "axios": "^0.17.1",
         "camelcase": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lodash.get": "^4.4.2",
     "peer-channel": "^0.1.2",
     "proxmise": "^1.0.0",
-    "tendermint": "^3.4.2",
+    "tendermint": "^4.0.2",
     "varstruct": "^6.1.2"
   }
 }


### PR DESCRIPTION
Upgrade the `tendermint` dependency for compatibility with Tendermint 0.31.5.

This should be published in step with https://github.com/nomic-io/lotion/pull/173.